### PR TITLE
HHKB modにnicola追加

### DIFF
--- a/keyboards/hhkb/keymaps/nicola/keymap.c
+++ b/keyboards/hhkb/keymaps/nicola/keymap.c
@@ -1,0 +1,89 @@
+#include QMK_KEYBOARD_H
+
+#include "nicola.h"
+
+#define _QWERTY 0
+#define _NICOLA 1
+#define _FN 2
+
+enum custom_keycodes {
+  QWERTY = SAFE_RANGE,
+  NICOLA,
+  FN
+};
+
+static uint16_t mkeys[] = {FN};
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [_QWERTY] = LAYOUT_JP(
+        KC_ESC, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9, KC_0, KC_MINS, KC_EQL, KC_JYEN, KC_BSPC,
+        KC_TAB, KC_Q, KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U, KC_I, KC_O, KC_P, KC_LBRC, KC_RBRC,
+        KC_LCTL, KC_A, KC_S, KC_D, KC_F, KC_G, KC_H, KC_J, KC_K, KC_L, KC_SCLN, KC_QUOT, KC_BSLS, KC_ENT,
+        KC_LSFT, KC_Z, KC_X, KC_C, KC_V, KC_B, KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH, KC_RO, KC_UP, KC_RSFT,
+        FN, KC_ZKHK, KC_LGUI, KC_LALT, KC_MHEN, KC_SPC, KC_HENK, KC_KANA, KC_RALT, FN, KC_LEFT, KC_DOWN, KC_RGHT),
+
+    [_NICOLA] = LAYOUT_JP(
+        KC_ESC, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9, KC_0, KC_MINS, KC_EQL, KC_JYEN, KC_BSPC,
+        KC_TAB, KC_Q, KC_W, KC_E, KC_R, KC_T, KC_Y, KC_U, KC_I, KC_O, KC_P, KC_LBRC, KC_RBRC,
+        KC_LCTL, KC_A, KC_S, KC_D, KC_F, KC_G, KC_H, KC_J, KC_K, KC_L, KC_SCLN, KC_QUOT, KC_BSLS, KC_ENT,
+        KC_LSFT, KC_Z, KC_X, KC_C, KC_V, KC_B, KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH, KC_RO, KC_UP, KC_RSFT,
+        FN, KC_ZKHK, KC_LGUI, KC_LALT, KC_MHEN, KC_SPC, KC_HENK, KC_KANA, KC_RALT, FN, KC_LEFT, KC_DOWN, KC_RGHT),
+
+    [_FN] = LAYOUT_JP(
+        KC_PWR, KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, KC_INS, KC_DEL,
+        KC_CAPS, _______, _______, _______, _______, _______, _______, _______, KC_PSCR, KC_SLCK, KC_PAUS, KC_UP, _______,
+        _______, KC_VOLD, KC_VOLU, KC_MUTE, KC_PWR, _______, KC_PAST, KC_PSLS, KC_HOME, KC_PGUP, KC_LEFT, KC_RGHT, _______, KC_PENT,
+        _______, _______, _______, _______, _______, _______, KC_PPLS, KC_PMNS, KC_END, KC_PGDN, KC_DOWN, _______, _______, _______,
+        _______, _______, _______, _______, _______, NICOLA, _______, _______, _______, _______, _______, _______, _______)
+};
+
+const macro_t *action_get_macro(keyrecord_t *record, uint8_t macro_id, uint8_t opt)
+{
+    return MACRO_NONE;
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case QWERTY:
+      if (record->event.pressed) {
+        print("mode just switched to qwerty and this is a huge string\n");
+        set_single_persistent_default_layer(_QWERTY);
+      }
+      return false;
+      break;
+    case NICOLA:
+      if (record->event.pressed) {
+        if (!layer_state_is(_NICOLA)) {
+          // 親指シフト
+          layer_on(_NICOLA);
+          // 親指シフト
+          register_code(KC_LANG1); // Mac
+          register_code(KC_HENK); // Win
+          unregister_code(KC_LANG1); // Mac
+          unregister_code(KC_HENK); // Win
+        } else {
+          // 親指シフト
+          layer_off(_NICOLA);
+          // 親指シフト
+          register_code(KC_LANG2); // Mac
+          register_code(KC_MHEN); // Win
+          unregister_code(KC_LANG2); // Mac
+          unregister_code(KC_MHEN); // Win
+        }
+      }
+      return false;
+      break;
+    case FN:
+      if (record->event.pressed) {
+        layer_on(_FN);
+      } else {
+        layer_off(_FN);
+      }
+      return false;
+      break;
+  }
+
+  // 親指シフト
+  return process_nicola(keycode, record, _NICOLA, KC_SPC, KC_HENK, mkeys);
+  // 親指シフト
+}

--- a/keyboards/hhkb/keymaps/nicola/nicola.c
+++ b/keyboards/hhkb/keymaps/nicola/nicola.c
@@ -1,0 +1,197 @@
+/* Copyright 2018-2019 eswai <@eswai>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+#include "nicola.h"
+
+static uint8_t ncl_chrcount = 0; // 文字キー入力のカウンタ (シフトキーを除く)
+static uint8_t ncl_keycount = 0; // シフトキーも含めた入力のカウンタ
+static uint8_t ncl_modcount = 0; // modifierキー入力のカウンタ
+static bool ncl_rshift = false; // 右シフトキーの状態
+static bool ncl_lshift = false; // 左シフトキーの状態
+static bool ncl_modrelease = false; // 全てのmodifierがリリースされた状態
+
+// 文字入力バッファ
+static uint16_t ninputs[5];
+
+// NICOLA配列のテーブル
+typedef struct {
+  char t[4]; // 単独
+  char l[4]; // 左シフト
+  char r[4]; // 右シフト
+} ncl_keymap;
+
+// NICOLA on QWERTY
+const ncl_keymap nmap[] = {
+  [KC_Q]    = {.t = ".",  .l = "la",  .r = ""},
+  [KC_W]    = {.t = "ka", .l = "e",   .r = "ga"},
+  [KC_E]    = {.t = "ta", .l = "ri",  .r = "da"},
+  [KC_R]    = {.t = "ko", .l = "lya", .r = "go"},
+  [KC_T]    = {.t = "sa", .l = "re",  .r = "za"},
+
+  [KC_Y]    = {.t = "ra", .l = "pa",  .r = "yo"},
+  [KC_U]    = {.t = "ti", .l = "di",  .r = "ni"},
+  [KC_I]    = {.t = "ku", .l = "gu",  .r = "ru"},
+  [KC_O]    = {.t = "tu", .l = "du",  .r = "ma"},
+  [KC_P]    = {.t = ",",  .l = "pi",  .r = "le"},
+
+  [KC_A]    = {.t = "u",  .l = "wo",  .r = "vu"},
+  [KC_S]    = {.t = "si", .l = "a",   .r = "zi"},
+  [KC_D]    = {.t = "te", .l = "na",  .r = "de"},
+  [KC_F]    = {.t = "ke", .l = "lyu", .r = "ge"},
+  [KC_G]    = {.t = "se", .l = "mo",  .r = "ze"},
+
+  [KC_H]    = {.t = "ha", .l = "ba",  .r = "mi"},
+  [KC_J]    = {.t = "to", .l = "do",  .r = "o"},
+  [KC_K]    = {.t = "ki", .l = "gi",  .r = "no"},
+  [KC_L]    = {.t = "i",  .l = "po",  .r = "lyo"},
+  [KC_SCLN] = {.t = "nn", .l = "",    .r = "ltu"},
+
+  [KC_Z]    = {.t = ".",  .l = "lu",  .r = ""},
+  [KC_X]    = {.t = "hi", .l = "-",   .r = "bi"},
+  [KC_C]    = {.t = "su", .l = "ro",  .r = "zu"},
+  [KC_V]    = {.t = "hu", .l = "ya",  .r = "bu"},
+  [KC_B]    = {.t = "he", .l = "li",  .r = "be"},
+
+  [KC_N]    = {.t = "me", .l = "pu",  .r = "nu"},
+  [KC_M]    = {.t = "so", .l = "zo",  .r = "yu"},
+  [KC_COMM] = {.t = "ne", .l = "pe",  .r = "mu"},
+  [KC_DOT]  = {.t = "ho", .l = "bo",  .r = "wa"},
+  [KC_SLSH] = {.t = "/",  .l = "?",    .r = "lo"},
+};
+
+// シフトキーの状態に応じて文字をPCへ送る
+void ncl_type(void) {
+  for (int i = 0; i < ncl_chrcount; i++) {
+    if (ninputs[i] == 0) break;
+    if (ncl_lshift) {
+      send_string(nmap[ninputs[i]].l);
+    } else if (ncl_rshift) {
+      send_string(nmap[ninputs[i]].r);
+    } else {
+      send_string(nmap[ninputs[i]].t);
+    }
+  }
+  ncl_clear();
+}
+
+// バッファをクリアする
+void ncl_clear(void) {
+  for (int i = 0; i < 5; i++) {
+    ninputs[i] = 0;
+  }
+  ncl_chrcount = 0;
+  ncl_keycount = 0;
+  ncl_lshift = false;
+  ncl_rshift = false;
+}
+
+bool process_nicola(uint16_t keycode, keyrecord_t *record, uint8_t ncl_layer, uint16_t lshiftkey, uint16_t rshiftkey, uint16_t modkeys[]) {
+  static int modkeys_size = sizeof(modkeys) / sizeof(modkeys[0]);
+
+  switch (keycode) {
+  case KC_LCTRL:
+  case KC_LSHIFT:
+  case KC_LALT:
+  case KC_LGUI:
+  case KC_RCTRL:
+  case KC_RSHIFT:
+  case KC_RALT:
+  case KC_RGUI:
+    if (record->event.pressed) {
+      ncl_modcount++;
+    } else {
+      ncl_modcount--;
+      if (ncl_modcount == 0) ncl_modrelease = true;
+    }
+    break;
+  }
+  for (int i = 0; i < modkeys_size; i++) {
+    if (keycode == modkeys[i]) {
+      if (record->event.pressed) {
+        ncl_modcount++;
+      } else {
+        ncl_modcount--;
+        if (ncl_modcount == 0) ncl_modrelease = true;
+      }
+    }
+  }
+
+  if (ncl_modcount > 0) {
+    return true;
+  }
+
+  if (layer_state_is(ncl_layer)) {
+
+    if (record->event.pressed) {
+      if (keycode == lshiftkey) {
+        ncl_lshift = true;
+        ncl_keycount++;
+        if (ncl_keycount > 1) ncl_type();
+        return false;
+      } else if (keycode == rshiftkey) {
+        ncl_rshift = true;
+        ncl_keycount++;
+        if (ncl_keycount > 1) ncl_type();
+        return false;
+      }
+      switch (keycode) {
+      case KC_A ... KC_Z: // 親指シフト処理するキー
+      case KC_SLSH:
+      case KC_DOT:
+      case KC_COMM:
+      case KC_SCLN:
+        ninputs[ncl_chrcount] = keycode;
+        ncl_chrcount++;
+        ncl_keycount++;
+        if (ncl_keycount > 1) ncl_type();
+        return false;
+        break;
+      default: // 親指シフトに関係ないキー
+        ncl_clear();
+        return true;
+        break;
+      }
+
+    } else { // key release
+      if (keycode == lshiftkey || keycode == rshiftkey) {
+        if (ncl_keycount == 1 && ncl_chrcount == 0) tap_code(keycode); // 単独lshiftkeyまたはrshiftkey
+        if (ncl_keycount > 0) ncl_type();
+        if (ncl_modrelease) { // modifierリリース時に押下されているキーの連打防止
+          ncl_modrelease = false;
+          return true;
+        }
+        return false;
+      }
+      switch (keycode) {
+      case KC_A ... KC_Z: // 親指シフト処理するキー
+      case KC_SLSH:
+      case KC_DOT:
+      case KC_COMM:
+      case KC_SCLN:
+        if (ncl_keycount > 0) ncl_type();
+        if (ncl_modrelease) {
+          ncl_modrelease = false;
+          return true;
+        }
+        return false;
+        break;
+      }
+    }
+  }
+
+  return true;
+}

--- a/keyboards/hhkb/keymaps/nicola/nicola.h
+++ b/keyboards/hhkb/keymaps/nicola/nicola.h
@@ -1,0 +1,19 @@
+/* Copyright 2018-2019 eswai <@eswai>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+void ncl_type(void);
+void ncl_clear(void);
+bool process_nicola(uint16_t, keyrecord_t *, uint8_t, uint16_t, uint16_t, uint16_t[]);

--- a/keyboards/hhkb/keymaps/nicola/rules.mk
+++ b/keyboards/hhkb/keymaps/nicola/rules.mk
@@ -1,0 +1,2 @@
+OPT_DEFS += -DHHKB_JP
+SRC += nicola.c


### PR DESCRIPTION
qmk_firmwareへのnicola実装と公開ありがとうございます。
crkbdのnicolaをベースにHHKB hasuコントローラに対応してみました。
このようにPRを送っていいのかわかりませんが、お送りしたいと思います。

nicola2, nicola3を参考にしつつ下記の変更をしてあります。

* レイヤーキーを三つ固定から可変に
* NLSHFT, NRSHFTは使用せず、既存のキーを使用し単独押下に対応
* modifierキーの同時押し対応
* modifierキーリリース時に押下されているキーがある場合の連打防止

私のhasuコントローラはbluetoothに対応したものではないので、bluetoothで動作するかは未検証です。

また本家のqmk_firmwareへの個人のキーマップ登録の流れなどは全く知らないのですが本家に取り込んでもらう予定などはないのでしょうか。
よろしくお願い致します。
